### PR TITLE
Redesign README with theme-aware SVG banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,6 @@
-# Hey, I'm RiVeR 👋
-
-## 🎯 2026 Roadmap
-
-*Daily progress toward becoming a better architect.*
-
-- **⚙️ Internals:** Deep-diving into **Python & Django internals** — understand the runtime, not just the framework.
-- **🐳 Infrastructure:** **Docker & Kubernetes** — moving from basic usage to production-grade deployment architecture.
-- **🚀 Systems:** Implementing **Kafka** for event-streaming and **ClickHouse** for columnar analytics at scale.
-- **🏗️ Databases:** **PostgreSQL internals**, query planning, indexing strategies, and how top companies scale their data layers.
-- **🤖 AI Engineering:** Integrating agentic workflows and LLM tooling into production backend systems.
-- **🔄 DevOps:** Hardening **CI/CD pipelines** for automated, zero-downtime deployments.
-
----
-
-## 🛠️ Currently Working On
-
-### ✅ Released
-
-| [TypeRush](https://github.com/withrvr/typerush) `v0.1.1` |
-| :--- |
-| A beautiful, fast typing-speed trainer that runs entirely in your terminal. One binary, zero setup. |
-| ⚡ Six modes — Time · Words · Quote · Code · Zen · Custom file |
-| 📊 Tracks every session locally with charts and personal bests |
-| 🌍 Linux · macOS · Windows · WSL · Git Bash |
-| `Rust` &nbsp;·&nbsp; `cargo install typerush` |
-
----
-
-### 🔨 In Development
-
-| [mute-ads](https://github.com/withrvr/mute-ads) | [prompt-navigator](https://github.com/withrvr/prompt-navigator) |
-| :--- | :--- |
-| Cross-browser extension that auto-mutes Hotstar ads during live sports & shows. Restores audio the moment content resumes. | Jump to any prompt in your AI chat. Lists, searches, favorites, and exports messages across ChatGPT, Claude, and Gemini. |
-| No blocking — just smart muting. | Clean, fast, eye-friendly. Click icon → find prompt → scroll instantly. |
-| `JavaScript` `WebExtensions API` | `JavaScript` `WebExtensions API` |
-
----
-
-### 🔬 Backend Deep-Dive
-
-| [url_shortener](https://github.com/withrvr/url_shortener) |
-| :--- |
-| Production-grade URL shortener built end-to-end as a learning lab. |
-| Going deep on Django internals, caching strategies, DB design, and rate limiting. |
-| Following the [roadmap.sh spec](https://roadmap.sh/projects/url-shortening-service) — understand every layer, not just make it work. |
-| `Python` `Django` `PostgreSQL` `Redis` |
-
----
-
-## 🤝 Connect
-
-[![Resume](https://img.shields.io/badge/Latest_Resume-24292E?style=for-the-badge&logo=googledrive&logoColor=white)](https://drive.google.com/file/d/1DpxMRZn38iOIc3Rbw9qZQx8Sl37KAiHK/view?usp=drivesdk) &nbsp;&nbsp;&nbsp; [![LeetCode](https://img.shields.io/badge/LeetCode_400+-FFA116?style=for-the-badge&logo=leetcode&logoColor=black)](https://leetcode.com/withrvr) &nbsp;&nbsp;&nbsp; [![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://linkedin.com/in/withrvr) &nbsp;&nbsp;&nbsp; [![X](https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/codewithrvr) &nbsp;&nbsp;&nbsp; [![Bio](https://img.shields.io/badge/Bio.Link-12bbad?style=for-the-badge&logo=linktree&logoColor=white)](http://withrvr.bio.link)
+<a href="https://github.com/withrvr/withrvr">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/banner-dark.svg">
+    <img alt="RiVeR's GitHub Profile README" src="assets/banner-light.svg">
+  </picture>
+</a>

--- a/assets/banner-dark.svg
+++ b/assets/banner-dark.svg
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" font-family="ConsolasFallback,Consolas,monospace" width="920px" height="340px" font-size="16px">
+<style>
+@font-face {
+src: local('Consolas'), local('Consolas Bold');
+font-family: 'ConsolasFallback';
+font-display: swap;
+-webkit-size-adjust: 109%;
+size-adjust: 109%;
+}
+.key {fill: #ffa657;}
+.value {fill: #a5d6ff;}
+.cc {fill: #616e7f;}
+text, tspan {white-space: pre;}
+</style>
+<rect width="920px" height="340px" fill="#161b22" rx="15"/>
+<text x="15" y="50" fill="#c9d1d9">
+<tspan x="15" y="50"></tspan>
+<tspan x="15" y="70">     ~~~     ~   ~~</tspan>
+<tspan x="15" y="90">  ~~     ~~~   ~     ~~~</tspan>
+<tspan x="15" y="110"></tspan>
+<tspan x="15" y="130"> ____   __     __  ____</tspan>
+<tspan x="15" y="150">|  _ \  \ \   / / |  _ \ </tspan>
+<tspan x="15" y="170">| |_) |  \ \ / /  | |_) |</tspan>
+<tspan x="15" y="190">|  _ &lt;    \ V /   |  _ &lt; </tspan>
+<tspan x="15" y="210">|_| \_\    \_/    |_| \_\ </tspan>
+<tspan x="15" y="230"></tspan>
+<tspan x="15" y="250">  ~~   ~~~    ~~    ~~</tspan>
+<tspan x="15" y="270"> ~   ~~    ~~~   ~~~   ~</tspan>
+<tspan x="15" y="290">   ~~~   ~~   ~~~    ~~</tspan>
+<tspan x="15" y="310"></tspan>
+</text>
+<text x="300" y="30" fill="#c9d1d9">
+<tspan x="300" y="30">RiVeR here -—————————————————————————————————————————————-</tspan>
+<tspan x="300" y="50"><tspan class="cc">. </tspan><tspan class="key">role</tspan>:<tspan class="cc"> .................. </tspan><tspan class="value">backend focus software engineer</tspan></tspan>
+<tspan x="300" y="70"><tspan class="cc">. </tspan><tspan class="key">language</tspan>.<tspan class="key">tech</tspan>:<tspan class="cc"> ................. </tspan><tspan class="value">python, django, fastapi</tspan></tspan>
+<tspan x="300" y="90"><tspan class="cc">. </tspan><tspan class="key">language</tspan>.<tspan class="key">real</tspan>:<tspan class="cc"> .......................... </tspan><tspan class="value">english, hindi</tspan></tspan>
+<tspan x="300" y="110"><tspan class="cc">. </tspan><tspan class="key">hobbies</tspan>:<tspan class="cc"> .................................. </tspan><tspan class="value">video gaming</tspan></tspan>
+<tspan x="300" y="150">- contact -——————————————————————————————————————————————-</tspan>
+<tspan x="300" y="170"><tspan class="cc">. </tspan><tspan class="key">email</tspan>:<tspan class="cc"> ........................ </tspan><tspan class="value">contactwithrvr@gmail.com</tspan></tspan>
+<tspan x="300" y="190"><tspan class="cc">. </tspan><tspan class="key">resume</tspan>:<tspan class="cc"> .......................... </tspan><tspan class="value">bit.ly/withrvr_resume</tspan></tspan>
+<tspan x="300" y="230">- 2026 Learning Roadmap -————————————————————————————————-</tspan>
+<tspan x="300" y="250"><tspan class="cc">. </tspan><tspan class="key">Internals</tspan>:<tspan class="cc"> ................ </tspan><tspan class="value">Python &amp; Django &amp; PostgreSQL</tspan></tspan>
+<tspan x="300" y="270"><tspan class="cc">. </tspan><tspan class="key">Infrastructure</tspan>:<tspan class="cc"> .................... </tspan><tspan class="value">Docker &amp; Kubernetes</tspan></tspan>
+<tspan x="300" y="290"><tspan class="cc">. </tspan><tspan class="key">Systems</tspan>:<tspan class="cc"> ......................................... </tspan><tspan class="value">Kafka</tspan></tspan>
+<tspan x="300" y="310"><tspan class="cc">. </tspan><tspan class="key">AI</tspan>:<tspan class="cc"> .................. </tspan><tspan class="value">agentic workflows and LLM tooling</tspan></tspan>
+</text>
+</svg>

--- a/assets/banner-light.svg
+++ b/assets/banner-light.svg
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" font-family="ConsolasFallback,Consolas,monospace" width="920px" height="340px" font-size="16px">
+<style>
+@font-face {
+src: local('Consolas'), local('Consolas Bold');
+font-family: 'ConsolasFallback';
+font-display: swap;
+-webkit-size-adjust: 109%;
+size-adjust: 109%;
+}
+.key {fill: #953800;}
+.value {fill: #0a3069;}
+.cc {fill: #c2cfde;}
+text, tspan {white-space: pre;}
+</style>
+<rect width="920px" height="340px" fill="#f6f8fa" rx="15"/>
+<text x="15" y="50" fill="#24292f">
+<tspan x="15" y="50"></tspan>
+<tspan x="15" y="70">     ~~~     ~   ~~</tspan>
+<tspan x="15" y="90">  ~~     ~~~   ~     ~~~</tspan>
+<tspan x="15" y="110"></tspan>
+<tspan x="15" y="130"> ____   __     __  ____</tspan>
+<tspan x="15" y="150">|  _ \  \ \   / / |  _ \ </tspan>
+<tspan x="15" y="170">| |_) |  \ \ / /  | |_) |</tspan>
+<tspan x="15" y="190">|  _ &lt;    \ V /   |  _ &lt; </tspan>
+<tspan x="15" y="210">|_| \_\    \_/    |_| \_\ </tspan>
+<tspan x="15" y="230"></tspan>
+<tspan x="15" y="250">  ~~   ~~~    ~~    ~~</tspan>
+<tspan x="15" y="270"> ~   ~~    ~~~   ~~~   ~</tspan>
+<tspan x="15" y="290">   ~~~   ~~   ~~~    ~~</tspan>
+<tspan x="15" y="310"></tspan>
+</text>
+<text x="300" y="30" fill="#24292f">
+<tspan x="300" y="30">RiVeR here -—————————————————————————————————————————————-</tspan>
+<tspan x="300" y="50"><tspan class="cc">. </tspan><tspan class="key">role</tspan>:<tspan class="cc"> .................. </tspan><tspan class="value">backend focus software engineer</tspan></tspan>
+<tspan x="300" y="70"><tspan class="cc">. </tspan><tspan class="key">language</tspan>.<tspan class="key">tech</tspan>:<tspan class="cc"> ................. </tspan><tspan class="value">python, django, fastapi</tspan></tspan>
+<tspan x="300" y="90"><tspan class="cc">. </tspan><tspan class="key">language</tspan>.<tspan class="key">real</tspan>:<tspan class="cc"> .......................... </tspan><tspan class="value">english, hindi</tspan></tspan>
+<tspan x="300" y="110"><tspan class="cc">. </tspan><tspan class="key">hobbies</tspan>:<tspan class="cc"> .................................. </tspan><tspan class="value">video gaming</tspan></tspan>
+<tspan x="300" y="150">- contact -——————————————————————————————————————————————-</tspan>
+<tspan x="300" y="170"><tspan class="cc">. </tspan><tspan class="key">email</tspan>:<tspan class="cc"> ........................ </tspan><tspan class="value">contactwithrvr@gmail.com</tspan></tspan>
+<tspan x="300" y="190"><tspan class="cc">. </tspan><tspan class="key">resume</tspan>:<tspan class="cc"> .......................... </tspan><tspan class="value">bit.ly/withrvr_resume</tspan></tspan>
+<tspan x="300" y="230">- 2026 Learning Roadmap -————————————————————————————————-</tspan>
+<tspan x="300" y="250"><tspan class="cc">. </tspan><tspan class="key">Internals</tspan>:<tspan class="cc"> ................ </tspan><tspan class="value">Python &amp; Django &amp; PostgreSQL</tspan></tspan>
+<tspan x="300" y="270"><tspan class="cc">. </tspan><tspan class="key">Infrastructure</tspan>:<tspan class="cc"> .................... </tspan><tspan class="value">Docker &amp; Kubernetes</tspan></tspan>
+<tspan x="300" y="290"><tspan class="cc">. </tspan><tspan class="key">Systems</tspan>:<tspan class="cc"> ......................................... </tspan><tspan class="value">Kafka</tspan></tspan>
+<tspan x="300" y="310"><tspan class="cc">. </tspan><tspan class="key">AI</tspan>:<tspan class="cc"> .................. </tspan><tspan class="value">agentic workflows and LLM tooling</tspan></tspan>
+</text>
+</svg>


### PR DESCRIPTION
## Summary
Replaced the markdown-based README with a visually appealing, theme-aware SVG banner system that automatically adapts to light and dark color schemes.

## Key Changes
- **Removed** verbose markdown content including roadmap details, project listings, and connection links from README.md
- **Added** two SVG banner files (`banner-dark.svg` and `banner-light.svg`) with:
  - ASCII art "RiVeR" logo with decorative wave patterns
  - Professional profile information (role, tech stack, languages, hobbies)
  - Contact details (email, resume link)
  - 2026 learning roadmap highlights
  - Theme-specific color schemes for optimal readability
- **Implemented** picture element with `prefers-color-scheme` media query to automatically serve the appropriate banner based on user's system theme preference

## Implementation Details
- SVG banners use Consolas monospace font with fallback for consistent terminal-style aesthetics
- Dark theme: Light text (#c9d1d9) on dark background (#161b22) with orange/blue accents
- Light theme: Dark text (#24292f) on light background (#f6f8fa) with brown/blue accents
- Responsive design with 920px width and 340px height, rounded corners (15px radius)
- Condensed information presentation while maintaining visual hierarchy and readability

https://claude.ai/code/session_01RDqWVkGnwYy6SeQLaLh1Du